### PR TITLE
Fix file type handling

### DIFF
--- a/templates/node-class.mustache
+++ b/templates/node-class.mustache
@@ -72,7 +72,7 @@
                     [keyName]: {
                         value: form[keyName],
                         options: {
-                            filename: `file.${ fileType(form[keyName]).ext }`
+                            filename: (fileType(form[keyName]) != null ? `file.${ fileType(form[keyName]).ext }` : `file` )
                         }
                     }
                 };


### PR DESCRIPTION
When a text file is uploaded using `multipart-formdata`, TypeError in the client code occurs because `file-type` module doesn't support text format. Therefore, I changed the code not to use an extension from `file-type` module when the module cannot detect file type.

The following screenshot is an example of the error. (I found this problem when I used MAX News Text Generator node generated by Node generator.)

<img width="1280" alt="filetype" src="https://user-images.githubusercontent.com/6851138/53680299-ced5af80-3d1c-11e9-9b12-b370a90f6c4a.png">